### PR TITLE
Correctly generate configuration when there are multiple columns but only one non-default operator class used

### DIFF
--- a/lib/schema_plus_pg_indexes/middleware/postgresql/dumper.rb
+++ b/lib/schema_plus_pg_indexes/middleware/postgresql/dumper.rb
@@ -16,7 +16,7 @@ module SchemaPlusPgIndexes
               else
                 index_dump.add_option "case_sensitive: false" unless index_def.case_sensitive?
                 unless index_def.operator_classes.blank?
-                  if index_def.operator_classes.values.uniq.length == 1
+                  if index_def.columns.uniq.length == 1 && index_def.operator_classes.values.uniq.length == 1
                     index_dump.add_option "operator_class: #{index_def.operator_classes.values.first.inspect}"
                   else
                     index_dump.add_option "operator_class: {" + index_def.operator_classes.map{|column, val| "#{column.inspect}=>#{val.inspect}"}.join(", ") + "}"

--- a/spec/schema_dumper_spec.rb
+++ b/spec/schema_dumper_spec.rb
@@ -97,6 +97,12 @@ describe "Schema dump" do
         expect(dump_posts).to match(/body.*index:.*operator_class: {"body"=>"text_pattern_ops", "string_no_default"=>"varchar_pattern_ops"}/)
       end
     end
+    
+    it "should define multi-column operator classes even if one column has no operator" do
+      with_index Post, [:body, :string_no_default], :operator_class => {string_no_default: 'varchar_pattern_ops'} do
+        expect(dump_posts).to match(/body.*index:.*operator_class: {"string_no_default"=>"varchar_pattern_ops"}/)
+      end
+    end
 
     it 'should dump proper operator_class with case_sensitive => false' do
       with_index Post, :body, :operator_class => 'text_pattern_ops', :case_sensitive => false do


### PR DESCRIPTION
If you have an index defined such as:

```ruby
add_index "animals", ["species_id", "adoption_status"], name: "index_animals_on_species_and_status", operator_class: {"adoption_status"=>"text_pattern_ops"}
```

Then schema_plus_pg_indexes will incorrectly dump the schema as:

```ruby
add_index "animals", ["species_id", "adoption_status"], name: "index_animals_on_species_and_status", operator_class: "text_pattern_ops"
```

This patch fixes that issue.